### PR TITLE
Adds genetics to runtimestation and increases power generation

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -826,18 +826,28 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay)
 "cK" = (
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -6;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/medical/medbay)
 "cL" = (
-/obj/structure/table,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /obj/item/disk/surgery/debug,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white/corner,
 /area/medical/medbay)
 "cN" = (
@@ -1277,12 +1287,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "es" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/medical/medbay)
@@ -2393,11 +2403,26 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"DW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/computer/scan_consolenew{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/medical/medbay)
 "EA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction)
+"EB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay)
 "EG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6637,9 +6662,9 @@ aa
 ae
 ab
 sE
-an
 sE
-an
+sE
+sE
 sE
 ab
 bv
@@ -6729,9 +6754,9 @@ aa
 ae
 ab
 sE
-ao
-ao
-ao
+an
+sE
+an
 sE
 ab
 bv
@@ -6820,11 +6845,11 @@ aa
 aa
 ae
 ab
-ab
-ab
+sE
+an
 ao
-ab
-ab
+an
+sE
 ab
 bv
 bJ
@@ -6912,11 +6937,11 @@ aa
 aa
 ae
 ac
-ac
+ab
 ab
 ao
 ab
-ac
+ab
 ac
 bv
 bK
@@ -8396,8 +8421,8 @@ dH
 by
 Qt
 by
-cm
-cK
+EB
+DW
 by
 cS
 cS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a genetics console, scanner and some monkeycubes to runtimestation's medbay area and roughly doubles the amount on not-solars to prevent power from running out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1 Makes testing genetics changes less of a pain. Useful for now and whenever that genetics update comes round.
2 Makes you not have to open the secret panel every 20 minutes to power everything, or not have to put infinite powercells in every APC you are going to need.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Iatots
add: runtimestation doesn't run out of power anymore, and has a basics genetics station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
